### PR TITLE
refactor and fix: 불필요한 state 제거 및 대체 & useEffect 비동기 state 변동 메모리릭 방지 처리

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,25 +4,24 @@ import { authService } from 'fbase'
 
 function App() {
   const [init, setInit] = useState(false)
-  const [isLoggedIn, setIsLoggedIn] = useState(false)
   const [userObj, setUserObj] = useState(null)
 
   useEffect(() => {
-    authService.onAuthStateChanged(user => {
-      if (user) {
-        setIsLoggedIn(true)
-        setUserObj(user)
-      } else {
-        setIsLoggedIn(false)
-      }
+    let isMounted = true
 
-      setInit(true)
+    authService.onAuthStateChanged(user => {
+      if(isMounted) {
+        setUserObj(user || null)
+        setInit(true)  
+      }
     })
+
+    return () => isMounted = false
   }, [])
 
   return (
     <>
-      {init ? <AppRouter isLoggedIn={isLoggedIn} userObj={userObj} /> : "Initializing...."}
+      {init ? <AppRouter userObj={userObj} /> : "Initializing...."}
       <footer>&copy Nwitter {new Date().getFullYear()}</footer>
     </>
   )

--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -5,7 +5,9 @@ import Home from "routes/Home"
 import Profile from "routes/Profile"
 import Navigation from "./Navigation"
 
-const AppRouter = ({ isLoggedIn, userObj }) => {
+const AppRouter = ({ userObj }) => {
+  const isLoggedIn = Boolean(userObj)
+
   return (
     <Router>
       {isLoggedIn && <Navigation />}

--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -7,13 +7,20 @@ const Home = ({ userObj }) => {
   const [nweets, setNweets] = useState([])
 
   useEffect(() => {
-    dbService.collection("nweets").onSnapshot(snapshot => {
-      const nweetArray = snapshot.docs.map(doc => ({
+    let isMounted = true
+
+    dbService.collection("nweets").onSnapshot(async snapshot => {
+      const nweetArray = await snapshot.docs.map(doc => ({
         id: doc.id,
         ...doc.data()
       }))
-      setNweets(nweetArray)
+      
+      if(isMounted) {
+        setNweets(nweetArray)
+      }
     })
+
+    return () => isMounted = false
   }, [])
 
   const onSubmit = async (event) => {


### PR DESCRIPTION
[description]
* App의 isLoggedIn state를 userObj로 대체하여 사용하고 사용하는 부분에서 제거
* useEffect 내부 비동기 처리가 컴포넌트 unmount 이후 setState 하는 메모리릭을 방지하기 위한 로직 처리
  - 참고: [Cancelling a Promise with React.useEffect](https://juliangaramendy.dev/use-promise-subscription/)